### PR TITLE
Fixed navigation detection

### DIFF
--- a/Hook/reddit_query.js
+++ b/Hook/reddit_query.js
@@ -1,16 +1,20 @@
-var isLoaded = false;
-
 function afterNavigate() {
     if ('/watch' === location.pathname) {
         var url = window.location.href;
         mainScript();
     }
 }
-(document.body || document.documentElement).addEventListener('transitionend',
-  function(/*TransitionEvent*/ event) {
-    if (event.propertyName === 'width' && event.target.id === 'progress' && $('#comments-selector').length === 0) {
+var observer = new WebKitMutationObserver(function(mutations) {
+  mutations.forEach(function(mutation) {
+    for (var i = 0; i < mutation.addedNodes.length; i++) {
+      var node = mutation.addedNodes[i];
+      if (node.tagName === "DIV" && node.id === "watch7-container") {
         afterNavigate();
+      }
     }
-}, true);
-// After page load
-afterNavigate();
+   })
+});
+observer.observe(document, { childList: true, attributes: true, subtree: true, characterData: true });
+$(document).ready(function() {
+  afterNavigate();
+});


### PR DESCRIPTION
This comment now detect any youtube navigation no matter what! It works
via two paths:
a) The document is loaded for the first time (page refresh, first time
entering the link, etc). In this case it loads through the normal
process using document ready.
b) The user navigates youtube and youtube uses it's pushstate
navigation. In this case there is a listener on the waiting for a div by
the name of watch7-container. This is the main container for comments
and other non video related content. This was the best option that loads
the fastest while still assuring #watch-discussion is loaded for the
injection script. This means if the #watch7-container id is deprecated,
the extension will cease to work and if our extension fails somewhere
doesn the line, this is the first place to look!
